### PR TITLE
launch the game via bash on linux

### DIFF
--- a/QModReloadedGUI/FrmMain.cs
+++ b/QModReloadedGUI/FrmMain.cs
@@ -1536,12 +1536,14 @@ public partial class FrmMain : Form
                 if (File.Exists(windowsPath))
                 {
                     path = windowsPath;
-                    gyk.StartInfo.WorkingDirectory = _gameLocation.location;
                 }
                 if (File.Exists(linuxPath))
                 {
-                    path = linuxPath;
+                    // Run bash as a middleman, otherwise game window does not appear
+                    path = "Z:\\bin\\bash";
+                    gyk.StartInfo.Arguments = "-c \"./Graveyard\\ Keeper.x86_64\"";
                 }
+                gyk.StartInfo.WorkingDirectory = _gameLocation.location;
                 gyk.StartInfo.FileName = path;
                 gyk.StartInfo.UseShellExecute = false;
                 gyk.Start();


### PR DESCRIPTION
Use bash as the command and run the game as a sub-command in bash - for whatever reason that resolves the game window not appearing :smile: 

The escaped quotes in the args are a bit ugly but necessary to make sure the executable is interpreted as a single argument